### PR TITLE
Fix API call for climate devices. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tuyaha",
-    version="0.0.6",
-    author="ThePinkOwl (Roger Miret Giné), Pavlo Annekov and original Tuya authors",
+    version="0.0.5",
+    author="Pavlo Annekov and original Tuya authors",
     author_email="paul.annekov@gmail.com",
     description="A Python library that implements a Tuya API endpoint that was specially designed for Home Assistant",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import setuptools
 
 with open("README.md", "r") as fh:
@@ -5,8 +6,8 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tuyaha",
-    version="0.0.5",
-    author="Pavlo Annekov and original Tuya authors",
+    version="0.0.6",
+    author="ThePinkOwl (Roger Miret Giné), Pavlo Annekov and original Tuya authors",
     author_email="paul.annekov@gmail.com",
     description="A Python library that implements a Tuya API endpoint that was specially designed for Home Assistant",
     long_description=long_description,

--- a/tuyaha/devices/climate.py
+++ b/tuyaha/devices/climate.py
@@ -24,7 +24,7 @@ class TuyaClimate(TuyaDevice):
         return self.data.get("temperature")
 
     def target_temperature_step(self):
-        return 1
+        return 0.5
 
     def current_fan_mode(self):
         """Return the fan setting."""
@@ -66,7 +66,7 @@ class TuyaClimate(TuyaDevice):
     def set_temperature(self, temperature):
         """Set new target temperature."""
         self.api.device_control(
-            self.obj_id, "temperatureSet", {"value": int(temperature)}
+            self.obj_id, "temperatureSet", {"value": float(temperature)}
         )
 
     def set_humidity(self, humidity):


### PR DESCRIPTION
Using floats instead of ints and changed the precision of steps to 0.5 instead of 1 as per the problems stated in this thread: https://community.home-assistant.io/t/smart-life-tuya-show-wrong-temperature/89093/69?u=rogermiret.