### PR TITLE
Manage exception in get_access_token

### DIFF
--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -58,9 +58,7 @@ class TuyaApi:
                 },
             )
         except RequestsConnectionError as ex:
-            if "NewConnectionError" in str(ex):
-                raise TuyaNETException from ex
-            raise ex
+            raise TuyaNetException from ex
 
         response_json = response.json()
         if response_json.get("responseStatus") == "error":
@@ -176,5 +174,5 @@ class TuyaAPIException(Exception):
     pass
 
 
-class TuyaNETException(Exception):
+class TuyaNetException(Exception):
     pass

--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -4,6 +4,7 @@ import time
 
 import requests
 from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import HTTPError as RequestsHTTPError
 
 from tuyaha.devices.factory import get_tuya_device
 
@@ -59,6 +60,12 @@ class TuyaApi:
             )
         except RequestsConnectionError as ex:
             raise TuyaNetException from ex
+
+        if response.status_code >= 500:
+            try:
+                response.raise_for_status()
+            except RequestsHTTPError as ex:
+                raise TuyaServerException from ex
 
         response_json = response.json()
         if response_json.get("responseStatus") == "error":
@@ -175,4 +182,8 @@ class TuyaAPIException(Exception):
 
 
 class TuyaNetException(Exception):
+    pass
+
+
+class TuyaServerException(Exception):
     pass

--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -58,10 +58,9 @@ class TuyaApi:
                 },
             )
         except RequestsConnectionError as ex:
-            if "NewConnectionError" not in str(ex):
-                raise TuyaAPIException from ex
-            else:
+            if "NewConnectionError" in str(ex):
                 raise TuyaNETException from ex
+            raise ex
 
         response_json = response.json()
         if response_json.get("responseStatus") == "error":


### PR DESCRIPTION
Hi,

this PR is to complete [this](https://github.com/home-assistant/core/pull/34057) Home Assistant PR.
Basically Tuya API will raise a new exception (TuyaNETException) if connection fails at startup.
This will be used in HA to retry component creation.
