### PR TITLE
Better __repr__ for devices

### DIFF
--- a/tuyaha/devices/base.py
+++ b/tuyaha/devices/base.py
@@ -46,3 +46,16 @@ class TuyaDevice:
             self.data = response["payload"]["data"]
             return True
         return
+
+    def __repr__(self):
+        module = self.__class__.__module__
+        if module is None or module == str.__class__.__module__:
+            module = ""
+        else:
+            module += "."
+        return '<{module}{clazz}: "{name}" ({obj_id})>'.format(
+            module=module,
+            clazz=self.__class__.__name__,
+            name=self.obj_name,
+            obj_id=self.obj_id
+        )


### PR DESCRIPTION
This changes the repr of devices in output from
```
<tuyaha.devices.light.TuyaLight at 0x7fb17e70a4e0>
```
which is the python default object representation to a bit more useful one with the device name and id:
```
<tuyaha.devices.light.TuyaLight: "Bedroom light" (bf53d1b52c385e4df8ghpy)>
```