### PR TITLE
fixed function support_color

### DIFF
--- a/tuyaha/devices/light.py
+++ b/tuyaha/devices/light.py
@@ -25,10 +25,7 @@ class TuyaLight(TuyaDevice):
             self.data["brightness"] = brightness
 
     def support_color(self):
-        if self.data.get("color") is None:
-            return False
-        else:
-            return True
+        return self.data["color_mode"] == "colour"
 
     def support_color_temp(self):
         if self.data.get("color_temp") is None:


### PR DESCRIPTION
that wasn't working due to a change in the API

This broke of course HomeAssistant integration resulting in the color picker not showing because the SUPPORT_COLOR wasn't set.

I don't know if this breaks other lights but this fixes my Lumary LED Strip