### PR TITLE
Use cached discovery, fix climate and light device values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+.idea/inspectionProfiles/profiles_settings.xml
+.idea/inspectionProfiles/Project_Default.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/tuyaha.iml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/tuyaha/devices/base.py
+++ b/tuyaha/devices/base.py
@@ -40,9 +40,9 @@ class TuyaDevice:
     def iconurl(self):
         return self.icon
 
-    def _update_data(self, key, value):
+    def _update_data(self, key, value, force_val=False):
         if self.data:
-            if self.data.get(key) is None:
+            if not force_val and self.data.get(key) is None:
                 return
             self.data[key] = value
             self.api.update_device_data(self.obj_id, self.data)
@@ -64,7 +64,10 @@ class TuyaDevice:
                 return
             for device in devices:
                 if device["id"] == self.obj_id:
-                    self.data = device["data"]
+                    if not self.data:
+                        self.data = device["data"]
+                    else:
+                        self.data.update(device["data"])
                     return True
             return
 

--- a/tuyaha/devices/base.py
+++ b/tuyaha/devices/base.py
@@ -47,6 +47,9 @@ class TuyaDevice:
 
     def _update_data(self, key, value, force_val=False):
         if self.data:
+            # device properties not provided by Tuya API are saved in the
+            # device cache only if force_val=True. This is used to force
+            # in cache missing API values (e.g color mode for light)
             if not force_val and self.data.get(key) is None:
                 return
             self.data[key] = value
@@ -60,9 +63,15 @@ class TuyaDevice:
             self._last_update = datetime.now()
         return success
 
+    # Update device cache using discovery or query command
+    # Due to the limitation of both command it is possible
+    # to choose which one to use. Because discovery return data
+    # for all devices, is preferred method with multiple device
+    # Query can be called with higher frequency but return
+    # values for a single device
     def _update(self, use_discovery):
 
-        """Avoid get cache value after control."""
+        # Avoid get cache value after control.
         difference = (datetime.now() - self._last_update).total_seconds()
         wait_delay = difference < 0.5
 

--- a/tuyaha/devices/base.py
+++ b/tuyaha/devices/base.py
@@ -1,8 +1,5 @@
 import time
 from datetime import datetime
-import logging
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class TuyaDevice:
@@ -108,7 +105,7 @@ class TuyaDevice:
 
                 result_code = get_result_code()
                 if result_code == "FrequentlyInvoke":
-                    _LOGGER.info(
+                    self.api.log_message(
                         "Method [Query] for device %s fails using poll interval %s - error: %s",
                         self.obj_id,
                         self.api.query_interval,

--- a/tuyaha/devices/base.py
+++ b/tuyaha/devices/base.py
@@ -1,7 +1,9 @@
 import time
 from datetime import datetime
+import logging
 
-QUERY_INTERVAL = 60
+_LOGGER = logging.getLogger(__name__)
+
 
 class TuyaDevice:
 
@@ -84,9 +86,9 @@ class TuyaDevice:
         else:
             # query can be called once every 60 seconds
             difference = (datetime.now() - self._last_query).total_seconds()
-            if difference < QUERY_INTERVAL:
+            if difference < self.api.query_interval:
                 return
-            if difference == QUERY_INTERVAL:
+            if difference == self.api.query_interval:
                 wait_delay = True
             if wait_delay:
                 time.sleep(0.5)
@@ -96,6 +98,22 @@ class TuyaDevice:
             self._last_query = datetime.now()
             if success:
                 data = response["payload"]["data"]
+
+            # Logging FrequentlyInvoke
+            else:
+                def get_result_code():
+                    if not response:
+                        return ""
+                    return response["header"]["code"]
+
+                result_code = get_result_code()
+                if result_code == "FrequentlyInvoke":
+                    _LOGGER.info(
+                        "Method [Query] for device %s fails using poll interval %s - error: %s",
+                        self.obj_id,
+                        self.api.query_interval,
+                        response["header"].get("msg", result_code),
+                    )
 
         if data:
             if not self.data:

--- a/tuyaha/devices/base.py
+++ b/tuyaha/devices/base.py
@@ -89,28 +89,15 @@ class TuyaDevice:
                 wait_delay = True
             if wait_delay:
                 time.sleep(0.5)
-            success, response = self.api.device_control(
-                self.obj_id, "QueryDevice", namespace="query"
-            )
-            self._last_query = datetime.now()
+
+            try:
+                success, response = self.api.device_control(
+                    self.obj_id, "QueryDevice", namespace="query"
+                )
+            finally:
+                self._last_query = datetime.now()
             if success:
                 data = response["payload"]["data"]
-
-            # Logging FrequentlyInvoke
-            else:
-                def get_result_code():
-                    if not response:
-                        return ""
-                    return response["header"]["code"]
-
-                result_code = get_result_code()
-                if result_code == "FrequentlyInvoke":
-                    self.api.log_message(
-                        "Method [Query] for device %s fails using poll interval %s - error: %s",
-                        self.obj_id,
-                        self.api.query_interval,
-                        response["header"].get("msg", result_code),
-                    )
 
         if data:
             if not self.data:

--- a/tuyaha/devices/climate.py
+++ b/tuyaha/devices/climate.py
@@ -183,6 +183,3 @@ class TuyaClimate(TuyaDevice):
     def turn_off(self):
         if self._control_device("turnOnOff", {"value": "0"}):
             self._update_data("state", "false")
-
-    def update(self):
-        return self._update(use_discovery=True)

--- a/tuyaha/devices/climate.py
+++ b/tuyaha/devices/climate.py
@@ -54,7 +54,8 @@ class TuyaClimate(TuyaDevice):
         """Set a divider used to calculate returned temperature. Default=0"""
         if divider < 0:
             raise ValueError("Temperature divider must be a positive value")
-        # this check is to avoid that divider is changed from calculated value
+        # this check is to avoid that divider is reset from
+        # calculated value when is set to 0
         if (self._divider_set and divider == 0) or divider > 0:
             self._divider = divider
         self._divider_set = divider > 0
@@ -75,26 +76,10 @@ class TuyaClimate(TuyaDevice):
         """Return if temperature values support decimal"""
         return self._divider >= 10
 
-    # temperature unit returned by API in many case is incorrect
-    # before taking the value returned by API, we apply some logic
-    # to try to identify the correct value. The determined value
-    # can always be overwritten using method set_unit()
     def temperature_unit(self):
         """Return the temperature unit for the device"""
         if not self._unit:
-            if self._divider == 0:
-                self.max_temp()  # this calculate divider first time
-            curr_temp = self.current_temperature()
-            if curr_temp is None:
-                self._unit = UNIT_CELSIUS  # default to celsius
-                return self._unit
-            # if current temperature is over 50 and does not use decimal
-            # we assume that the unit is fahrenheit. This can always be
-            # overwritten by method set_unit()
-            if curr_temp > 50 and not self.has_decimal():
-                self._unit = UNIT_FAHRENHEIT
-            else:
-                self._unit = self.data.get("temp_unit", UNIT_CELSIUS)
+            self._unit = self.data.get("temp_unit", UNIT_CELSIUS)
         return self._unit
 
     def current_humidity(self):

--- a/tuyaha/devices/climate.py
+++ b/tuyaha/devices/climate.py
@@ -2,8 +2,52 @@ from tuyaha.devices.base import TuyaDevice
 
 
 class TuyaClimate(TuyaDevice):
+
+    def __init__(self, data, api):
+        super().__init__(data, api)
+        self._unit = None
+        self._divider = 0
+        self._ct_divider = 0
+
+    def _set_decimal(self, val, divider=0):
+        if val is None:
+            return None
+        if divider == 0:
+            divider = self._divider
+            if divider == 0:
+                if val > 500 or val < -100:
+                    divider = 100
+                else:
+                    divider = 1
+                self._divider = divider
+
+        return round(float(val / divider), 2)
+
+    def set_unit(self, unit):
+        self._unit = unit
+
+    def set_temp_divider(self, divider):
+        self._divider = divider
+
+    def set_curr_temp_divider(self, divider):
+        self._ct_divider = divider
+
+    def has_decimal(self):
+        return self._divider >= 10
+
     def temperature_unit(self):
-        return self.data.get("temp_unit")
+        if not self._unit:
+            if self._divider == 0:
+                self.max_temp()
+            curr_temp = self.current_temperature()
+            if curr_temp is None:
+                self._unit = "CELSIUS"
+                return self._unit
+            if curr_temp > 50 and not self.has_decimal():
+                self._unit = "FAHRENHEIT"
+            else:
+                self._unit = self.data.get("temp_unit", "CELSIUS")
+        return self._unit
 
     def current_humidity(self):
         pass
@@ -18,13 +62,18 @@ class TuyaClimate(TuyaDevice):
         return self.data.get("support_mode")
 
     def current_temperature(self):
-        return self.data.get("current_temperature")
+        curr_temp = self._set_decimal(self.data.get("current_temperature"), self._ct_divider)
+        if curr_temp is None:
+            return self.target_temperature()
+        return curr_temp
 
     def target_temperature(self):
-        return self.data.get("temperature")
+        return self._set_decimal(self.data.get("temperature"), self._ct_divider)
 
     def target_temperature_step(self):
-        return 0.5
+        if self.has_decimal():
+            return 0.5
+        return 1.0
 
     def current_fan_mode(self):
         """Return the fan setting."""
@@ -52,10 +101,10 @@ class TuyaClimate(TuyaDevice):
         return None
 
     def min_temp(self):
-        return self.data.get("min_temper")
+        return self._set_decimal(self.data.get("min_temper"))
 
     def max_temp(self):
-        return self.data.get("max_temper")
+        return self._set_decimal(self.data.get("max_temper"))
 
     def min_humidity(self):
         pass
@@ -65,9 +114,20 @@ class TuyaClimate(TuyaDevice):
 
     def set_temperature(self, temperature):
         """Set new target temperature."""
-        self.api.device_control(
-            self.obj_id, "temperatureSet", {"value": float(temperature)}
-        )
+        if self._ct_divider > 0:
+            divider = self._ct_divider
+        else:
+            divider = self._divider
+        if divider == 0:
+            divider = 1
+
+        if not self.has_decimal():
+            temp_val = round(float(temperature))
+            set_val = temp_val * divider
+        else:
+            temp_val = set_val = round(float(temperature) * divider)
+        if self._control_device("temperatureSet", {"value": temp_val}):
+            self._update_data("temperature", set_val)
 
     def set_humidity(self, humidity):
         """Set new target humidity."""
@@ -75,11 +135,18 @@ class TuyaClimate(TuyaDevice):
 
     def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
-        self.api.device_control(self.obj_id, "windSpeedSet", {"value": fan_mode})
+        if self._control_device("windSpeedSet", {"value": fan_mode}):
+            fanList = self.fan_list()
+            if fan_mode in fanList:
+                val = str(fanList.index(fan_mode) + 1)
+            else:
+                val = fan_mode
+            self._update_data("windspeed", val)
 
     def set_operation_mode(self, operation_mode):
         """Set new target operation mode."""
-        self.api.device_control(self.obj_id, "modeSet", {"value": operation_mode})
+        if self._control_device("modeSet", {"value": operation_mode}):
+            self._update_data("mode", operation_mode)
 
     def set_swing_mode(self, swing_mode):
         """Set new target swing operation."""
@@ -110,7 +177,12 @@ class TuyaClimate(TuyaDevice):
             return False
 
     def turn_on(self):
-        self.api.device_control(self.obj_id, "turnOnOff", {"value": "1"})
+        if self._control_device("turnOnOff", {"value": "1"}):
+            self._update_data("state", "true")
 
     def turn_off(self):
-        self.api.device_control(self.obj_id, "turnOnOff", {"value": "0"})
+        if self._control_device("turnOnOff", {"value": "0"}):
+            self._update_data("state", "false")
+
+    def update(self):
+        return self._update(use_discovery=True)

--- a/tuyaha/devices/cover.py
+++ b/tuyaha/devices/cover.py
@@ -27,6 +27,3 @@ class TuyaCover(TuyaDevice):
         if support is None:
             return False
         return support
-
-    def update(self):
-        return self._update(use_discovery=True)

--- a/tuyaha/devices/cover.py
+++ b/tuyaha/devices/cover.py
@@ -2,30 +2,31 @@ from tuyaha.devices.base import TuyaDevice
 
 
 class TuyaCover(TuyaDevice):
+
     def state(self):
         state = self.data.get("state")
         return state
 
     def open_cover(self):
         """Open the cover."""
-        success, _response = self.api.device_control(self.obj_id, "turnOnOff", {"value": "1"})
-
-        if success:
-            self.data["state"] = True
+        if self._control_device("turnOnOff", {"value": "1"}):
+            self._update_data("state", 1)
 
     def close_cover(self):
         """Close cover."""
-        success, _response = self.api.device_control(self.obj_id, "turnOnOff", {"value": "0"})
-
-        if success:
-            self.data["state"] = False
+        if self._control_device("turnOnOff", {"value": "0"}):
+            self._update_data("state", 2)
 
     def stop_cover(self):
         """Stop the cover."""
-        self.api.device_control(self.obj_id, "startStop", {"value": "0"})
+        if self._control_device("startStop", {"value": "0"}):
+            self._update_data("state", 3)
 
     def support_stop(self):
         support = self.data.get("support_stop")
         if support is None:
             return False
         return support
+
+    def update(self):
+        return self._update(use_discovery=True)

--- a/tuyaha/devices/fan.py
+++ b/tuyaha/devices/fan.py
@@ -2,12 +2,6 @@ from tuyaha.devices.base import TuyaDevice
 
 
 class TuyaFanDevice(TuyaDevice):
-    def state(self):
-        state = self.data.get("state")
-        if state == "true":
-            return True
-        else:
-            return False
 
     def speed(self):
         return self.data.get("speed")
@@ -23,26 +17,24 @@ class TuyaFanDevice(TuyaDevice):
         return self.data.get("direction")
 
     def set_speed(self, speed):
-        self.api.device_control(self.obj_id, "windSpeedSet", {"value": speed})
+        if self._control_device("windSpeedSet", {"value": speed}):
+            self._update_data("speed", speed)
 
     def oscillate(self, oscillating):
         if oscillating:
             command = "swingOpen"
         else:
             command = "swingClose"
-        self.api.device_control(self.obj_id, command)
+        if self._control_device(command):
+            self._update_data("direction", oscillating)
 
     def turn_on(self):
-        success, _response = self.api.device_control(self.obj_id, "turnOnOff", {"value": "1"})
-
-        if success:
-            self.data["state"] = "true"
+        if self._control_device("turnOnOff", {"value": "1"}):
+            self._update_data("state", "true")
 
     def turn_off(self):
-        success, _response = self.api.device_control(self.obj_id, "turnOnOff", {"value": "0"})
-
-        if success:
-            self.data["state"] = "false"
+        if self._control_device("turnOnOff", {"value": "0"}):
+            self._update_data("state", "false")
 
     def support_oscillate(self):
         if self.oscillating() is None:

--- a/tuyaha/devices/light.py
+++ b/tuyaha/devices/light.py
@@ -1,57 +1,80 @@
 from tuyaha.devices.base import TuyaDevice
 
+"""The minimum brightness value set in the API that does not turn off the light."""
+MIN_BRIGHTNESS = 10.3
+BRIGHTNESS_WHITE_RANGE = (10, 1000)
+BRIGHTNESS_COLOR_RANGE = (1, 255)
+BRIGHTNESS_STD_RANGE = (1, 255)
+
 
 class TuyaLight(TuyaDevice):
-    def state(self):
-        state = self.data.get("state")
-        if state == "true":
-            return True
-        else:
-            return False
+    def __init__(self, data, api):
+        super().__init__(data, api)
+        self._support_color = False
+
+    def set_support_color(self, supported):
+        self._support_color = supported
+
+    def _color_mode(self):
+        work_mode = self.data.get("color_mode", "white")
+        return True if work_mode == "colour" else False
+
+    @staticmethod
+    def _scale(val, src, dst):
+        """Scale the given value from the scale of src to the scale of dst."""
+        if val < 0:
+            return dst[0]
+        return ((val - src[0]) / (src[1] - src[0])) * (dst[1] - dst[0]) + dst[0]
 
     def brightness(self):
-        work_mode = self.data.get("color_mode")
-        if work_mode == "colour" and "color" in self.data:
-            brightness = int(self.data.get("color").get("brightness") * 255 / 100)
+        brightness = -1
+        if self._color_mode():
+            if "color" in self.data:
+                brightness = int(self.data.get("color").get("brightness", "-1"))
         else:
-            brightness = self.data.get("brightness")
-        return brightness
+            brightness = int(self.data.get("brightness", "-1"))
+        ret_val = TuyaLight._scale(
+            brightness,
+            self._brightness_range(),
+            BRIGHTNESS_STD_RANGE,
+        )
+        return round(ret_val)
 
     def _set_brightness(self, brightness):
-        work_mode = self.data.get("color_mode")
-        if work_mode == "colour":
-            self.data["color"]["brightness"] = brightness
+        if self._color_mode():
+            data = self.data.get("color", {})
+            data["brightness"] = brightness
+            self._update_data("color", data, force_val=True)
         else:
-            self.data["brightness"] = brightness
+            self._update_data("brightness", brightness)
+
+    def _brightness_range(self):
+        if self._color_mode():
+            return BRIGHTNESS_COLOR_RANGE
+        else:
+            return BRIGHTNESS_WHITE_RANGE
 
     def support_color(self):
-        if self.data.get("color") is None:
-            return False
-        else:
-            return True
+        if not self._support_color:
+            if self.data.get("color") or self.data.get("color_mode") == "colour":
+                self._support_color = True
+        return self._support_color
 
     def support_color_temp(self):
-        if self.data.get("color_temp") is None:
-            return False
-        else:
-            return True
+        return self.data.get("color_temp") is not None
 
     def hs_color(self):
-        if self.data.get("color") is None:
-            return None
-        else:
-            work_mode = self.data.get("color_mode")
-            if work_mode == "colour":
-                color = self.data.get("color")
-                return color.get("hue"), color.get("saturation")
+        if self.support_color():
+            color = self.data.get("color")
+            if self._color_mode() and color:
+                return color.get("hue", 0.0), float(color.get("saturation", 0.0)) * 100
             else:
                 return 0.0, 0.0
+        else:
+            return None
 
     def color_temp(self):
-        if self.data.get("color_temp") is None:
-            return None
-        else:
-            return self.data.get("color_temp")
+        return self.data.get("color_temp")
 
     def min_color_temp(self):
         return 10000
@@ -60,37 +83,62 @@ class TuyaLight(TuyaDevice):
         return 1000
 
     def turn_on(self):
-        success, _response = self.api.device_control(self.obj_id, "turnOnOff", {"value": "1"})
-
-        if success:
-            self.data["state"] = "true"
+        if self._control_device("turnOnOff", {"value": "1"}):
+            self._update_data("state", "true")
 
     def turn_off(self):
-        success, _response = self.api.device_control(self.obj_id, "turnOnOff", {"value": "0"})
-
-        if success:
-            self.data["state"] = "false"
+        if self._control_device("turnOnOff", {"value": "0"}):
+            self._update_data("state", "false")
 
     def set_brightness(self, brightness):
         """Set the brightness(0-255) of light."""
-        value = int(brightness * 100 / 255)
-        self.api.device_control(self.obj_id, "brightnessSet", {"value": value})
+        if int(brightness) > 0:
+            """convert to scale 0-100 with MIN_BRIGHTNESS."""
+            set_value = TuyaLight._scale(
+                brightness,
+                BRIGHTNESS_STD_RANGE,
+                (MIN_BRIGHTNESS, 100),
+            )
+            value = TuyaLight._scale(
+                brightness,
+                BRIGHTNESS_STD_RANGE,
+                self._brightness_range(),
+            )
+            if self._control_device("brightnessSet", {"value": round(set_value, 1)}):
+                self._update_data("state", "true")
+                self._set_brightness(round(value))
+        else:
+            self.turn_off()
 
     def set_color(self, color):
         """Set the color of light."""
-        hsv_color = {}
-        hsv_color["hue"] = color[0]
-        hsv_color["saturation"] = color[1] / 100
+        cur_brightness = self.data.get("color", {}).get(
+            "brightness", BRIGHTNESS_COLOR_RANGE[0]
+        )
+        hsv_color = {
+            "hue": color[0] if color[1] != 0 else 0,  # color white
+            "saturation": color[1] / 100,
+        }
         if len(color) < 3:
-            hsv_color["brightness"] = int(self.brightness()) / 255.0
+            hsv_color["brightness"] = cur_brightness
         else:
             hsv_color["brightness"] = color[2]
         # color white
-        if hsv_color["saturation"] == 0:
-            hsv_color["hue"] = 0
-        self.api.device_control(self.obj_id, "colorSet", {"color": hsv_color})
+        white_mode = hsv_color["saturation"] == 0
+        is_color = self._color_mode()
+        if self._control_device("colorSet", {"color": hsv_color}):
+            self._update_data("state", "true")
+            self._update_data("color", hsv_color, force_val=True)
+            if not is_color and not white_mode:
+                self._update_data("color_mode", "colour")
+            elif is_color and white_mode:
+                self._update_data("color_mode", "white")
 
     def set_color_temp(self, color_temp):
-        self.api.device_control(
-            self.obj_id, "colorTemperatureSet", {"value": color_temp}
-        )
+        if self._control_device("colorTemperatureSet", {"value": color_temp}):
+            self._update_data("state", "true")
+            self._update_data("color_mode", "white")
+            self._update_data("color_temp", color_temp)
+
+    def update(self):
+        return self._update(use_discovery=True)

--- a/tuyaha/devices/light.py
+++ b/tuyaha/devices/light.py
@@ -4,17 +4,18 @@ from tuyaha.devices.base import TuyaDevice
 MIN_BRIGHTNESS = 10.3
 BRIGHTNESS_STD_RANGE = (1, 255)
 
-COLTEMP_STATUS_RANGE = (1000, 36294)
 COLTEMP_SET_RANGE = (1000, 10000)
 COLTEMP_KELV_RANGE = (2700, 6500)
 
 
 class TuyaLight(TuyaDevice):
+
     def __init__(self, data, api):
         super().__init__(data, api)
         self._support_color = False
         self.brightness_white_range = BRIGHTNESS_STD_RANGE
         self.brightness_color_range = BRIGHTNESS_STD_RANGE
+        self.color_temp_range = COLTEMP_SET_RANGE
 
     def force_support_color(self):
         self._support_color = True
@@ -81,7 +82,7 @@ class TuyaLight(TuyaDevice):
         temp = self.data.get("color_temp")
         ret_value = TuyaLight._scale(
             temp,
-            COLTEMP_STATUS_RANGE,
+            self.color_temp_range,
             COLTEMP_KELV_RANGE,
         )
         return round(ret_value)
@@ -156,9 +157,6 @@ class TuyaLight(TuyaDevice):
             data_value = TuyaLight._scale(
                 color_temp,
                 COLTEMP_KELV_RANGE,
-                COLTEMP_STATUS_RANGE,
+                self.color_temp_range,
             )
             self._update_data("color_temp", round(data_value))
-
-    def update(self):
-        return self._update(use_discovery=True)

--- a/tuyaha/devices/light.py
+++ b/tuyaha/devices/light.py
@@ -1,10 +1,15 @@
 from tuyaha.devices.base import TuyaDevice
 
-"""The minimum brightness value set in the API that does not turn off the light."""
+# The minimum brightness value set in the API that does not turn off the light
 MIN_BRIGHTNESS = 10.3
+
+# the default range used to return brightness
 BRIGHTNESS_STD_RANGE = (1, 255)
 
+# the default range used to set color temperature
 COLTEMP_SET_RANGE = (1000, 10000)
+
+# the default range used to return color temperature (in kelvin)
 COLTEMP_KELV_RANGE = (2700, 6500)
 
 
@@ -17,6 +22,8 @@ class TuyaLight(TuyaDevice):
         self.brightness_color_range = BRIGHTNESS_STD_RANGE
         self.color_temp_range = COLTEMP_SET_RANGE
 
+    # if color support is not reported by API can be forced by this method
+    # the attribute _support_color is used by method support_color()
     def force_support_color(self):
         self._support_color = True
 
@@ -32,12 +39,14 @@ class TuyaLight(TuyaDevice):
         return ((val - src[0]) / (src[1] - src[0])) * (dst[1] - dst[0]) + dst[0]
 
     def brightness(self):
+        """Return the brightness based on the light status scaled to standard range"""
         brightness = -1
         if self._color_mode():
             if "color" in self.data:
                 brightness = int(self.data.get("color").get("brightness", "-1"))
         else:
             brightness = int(self.data.get("brightness", "-1"))
+        # returned value is scaled using standard range
         ret_val = TuyaLight._scale(
             brightness,
             self._brightness_range(),
@@ -54,21 +63,25 @@ class TuyaLight(TuyaDevice):
             self._update_data("brightness", brightness)
 
     def _brightness_range(self):
+        """return the configured brightness range based on the light status"""
         if self._color_mode():
             return self.brightness_color_range
         else:
             return self.brightness_white_range
 
     def support_color(self):
+        """return if the light support color"""
         if not self._support_color:
             if self.data.get("color") or self.data.get("color_mode") == "colour":
                 self._support_color = True
         return self._support_color
 
     def support_color_temp(self):
+        """return if the light support color temperature"""
         return self.data.get("color_temp") is not None
 
     def hs_color(self):
+        """return current hs color"""
         if self.support_color():
             color = self.data.get("color")
             if self._color_mode() and color:
@@ -79,7 +92,9 @@ class TuyaLight(TuyaDevice):
             return None
 
     def color_temp(self):
+        """return current color temperature scaled with standard kelvin range"""
         temp = self.data.get("color_temp")
+        # convert color temperature to kelvin scale for returned value
         ret_value = TuyaLight._scale(
             temp,
             self.color_temp_range,
@@ -104,19 +119,20 @@ class TuyaLight(TuyaDevice):
     def set_brightness(self, brightness):
         """Set the brightness(0-255) of light."""
         if int(brightness) > 0:
-            """convert to scale 0-100 with MIN_BRIGHTNESS."""
+            # convert to scale 0-100 with MIN_BRIGHTNESS to set the value
             set_value = TuyaLight._scale(
                 brightness,
                 BRIGHTNESS_STD_RANGE,
                 (MIN_BRIGHTNESS, 100),
             )
-            value = TuyaLight._scale(
-                brightness,
-                BRIGHTNESS_STD_RANGE,
-                self._brightness_range(),
-            )
             if self._control_device("brightnessSet", {"value": round(set_value, 1)}):
                 self._update_data("state", "true")
+                # convert to scale configured for brightness range to update the cache
+                value = TuyaLight._scale(
+                    brightness,
+                    BRIGHTNESS_STD_RANGE,
+                    self._brightness_range(),
+                )
                 self._set_brightness(round(value))
         else:
             self.turn_off()
@@ -146,6 +162,8 @@ class TuyaLight(TuyaDevice):
                 self._update_data("color_mode", "white")
 
     def set_color_temp(self, color_temp):
+        """Set the color temperature of light."""
+        # convert to scale configured for color temperature to update the value
         set_value = TuyaLight._scale(
             color_temp,
             COLTEMP_KELV_RANGE,
@@ -154,6 +172,7 @@ class TuyaLight(TuyaDevice):
         if self._control_device("colorTemperatureSet", {"value": round(set_value)}):
             self._update_data("state", "true")
             self._update_data("color_mode", "white")
+            # convert to scale configured for color temperature to update the cache
             data_value = TuyaLight._scale(
                 color_temp,
                 COLTEMP_KELV_RANGE,

--- a/tuyaha/devices/light.py
+++ b/tuyaha/devices/light.py
@@ -2,8 +2,6 @@ from tuyaha.devices.base import TuyaDevice
 
 """The minimum brightness value set in the API that does not turn off the light."""
 MIN_BRIGHTNESS = 10.3
-BRIGHTNESS_WHITE_RANGE = (10, 1000)
-BRIGHTNESS_COLOR_RANGE = (1, 255)
 BRIGHTNESS_STD_RANGE = (1, 255)
 
 COLTEMP_STATUS_RANGE = (1000, 36294)
@@ -15,9 +13,11 @@ class TuyaLight(TuyaDevice):
     def __init__(self, data, api):
         super().__init__(data, api)
         self._support_color = False
+        self.brightness_white_range = BRIGHTNESS_STD_RANGE
+        self.brightness_color_range = BRIGHTNESS_STD_RANGE
 
-    def set_support_color(self, supported):
-        self._support_color = supported
+    def force_support_color(self):
+        self._support_color = True
 
     def _color_mode(self):
         work_mode = self.data.get("color_mode", "white")
@@ -54,9 +54,9 @@ class TuyaLight(TuyaDevice):
 
     def _brightness_range(self):
         if self._color_mode():
-            return BRIGHTNESS_COLOR_RANGE
+            return self.brightness_color_range
         else:
-            return BRIGHTNESS_WHITE_RANGE
+            return self.brightness_white_range
 
     def support_color(self):
         if not self._support_color:
@@ -123,7 +123,7 @@ class TuyaLight(TuyaDevice):
     def set_color(self, color):
         """Set the color of light."""
         cur_brightness = self.data.get("color", {}).get(
-            "brightness", BRIGHTNESS_COLOR_RANGE[0]
+            "brightness", self.brightness_color_range[0]
         )
         hsv_color = {
             "hue": color[0] if color[1] != 0 else 0,  # color white

--- a/tuyaha/devices/scene.py
+++ b/tuyaha/devices/scene.py
@@ -8,5 +8,5 @@ class TuyaScene(TuyaDevice):
     def activate(self):
         self.api.device_control(self.obj_id, "turnOnOff", {"value": "1"})
 
-    def update(self):
+    def update(self, use_discovery=True):
         return True

--- a/tuyaha/devices/switch.py
+++ b/tuyaha/devices/switch.py
@@ -12,5 +12,5 @@ class TuyaSwitch(TuyaDevice):
         if self._control_device("turnOnOff", {"value": "0"}):
             self._update_data("state", False)
 
-    def update(self):
+    def update(self, use_discovery=True):
         return self._update(use_discovery=True)

--- a/tuyaha/devices/switch.py
+++ b/tuyaha/devices/switch.py
@@ -1,35 +1,16 @@
-import time
 
 from tuyaha.devices.base import TuyaDevice
 
 
 class TuyaSwitch(TuyaDevice):
-    def state(self):
-        state = self.data.get("state")
-        if state is None:
-            return None
-        return state
 
     def turn_on(self):
-        success, _response = self.api.device_control(self.obj_id, "turnOnOff", {"value": "1"})
-
-        if success:
-            self.data["state"] = True
+        if self._control_device("turnOnOff", {"value": "1"}):
+            self._update_data("state", True)
 
     def turn_off(self):
-        success, _response = self.api.device_control(self.obj_id, "turnOnOff", {"value": "0"})
+        if self._control_device("turnOnOff", {"value": "0"}):
+            self._update_data("state", False)
 
-        if success:
-            self.data["state"] = False
-
-    # workaround for https://github.com/PaulAnnekov/tuyaha/issues/3
     def update(self):
-        """Avoid get cache value after control."""
-        time.sleep(0.5)
-        devices = self.api.discovery()
-        if not devices:
-            return
-        for device in devices:
-            if device["id"] == self.obj_id:
-                self.data = device["data"]
-                return True
+        return self._update(use_discovery=True)

--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -40,7 +40,8 @@ SESSION = TuyaSession()
 
 class TuyaApi:
 
-    def __init__(self):
+    def __init__(self, log_level_warn=True):
+        self._log_level_warn = log_level_warn
         self._requestSession = None
         self._discovered_devices = None
         self._last_discover = None
@@ -66,6 +67,12 @@ class TuyaApi:
     def query_interval(self, val):
         if val >= MIN_QUERY_INTERVAL:
             self._query_interval = val
+
+    def log_message(self, message, *args):
+        if self._log_level_warn:
+            _LOGGER.warning(message, *args)
+        else:
+            _LOGGER.debug(message, *args)
 
     def init(self, username, password, countryCode, bizType=""):
         SESSION.username = username
@@ -178,7 +185,7 @@ class TuyaApi:
                     # Logging FrequentlyInvoke
                     elif result_code == "FrequentlyInvoke":
                         self._discovery_fail_count += 1
-                        _LOGGER.info(
+                        self.log_message(
                             "Method [Discovery] fails %s time(s) using poll interval %s - error: %s",
                             self._discovery_fail_count,
                             self.discovery_interval,

--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -206,9 +206,18 @@ class TuyaApi:
         if namespace != "discovery":
             payload["devId"] = devId
         data = {"header": header, "payload": payload}
-        response = self.requestSession.post(
-            (TUYACLOUDURL + "/homeassistant/skill").format(SESSION.region), json=data
-        )
+        try:
+            response = self.requestSession.post(
+                (TUYACLOUDURL + "/homeassistant/skill").format(SESSION.region), json=data
+            )
+        except RequestsConnectionError as ex:
+            _LOGGER.debug(
+                "request error, error code is %s, device %s",
+                ex,
+                devId,
+            )
+            return
+
         if not response.ok:
             _LOGGER.warning(
                 "request error, status code is %d, device %s",

--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -12,10 +12,10 @@ from tuyaha.devices.factory import get_tuya_device
 TUYACLOUDURL = "https://px1.tuya{}.com"
 DEFAULTREGION = "us"
 
-MIN_DISCOVERY_INTERVAL = 60.0
-DEF_DISCOVERY_INTERVAL = 305.0
+MIN_DISCOVERY_INTERVAL = 10.0
+DEF_DISCOVERY_INTERVAL = 60.0
 MIN_QUERY_INTERVAL = 10.0
-DEF_QUERY_INTERVAL = 60.0
+DEF_QUERY_INTERVAL = 30.0
 REFRESHTIME = 60 * 60 * 12
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,11 +57,9 @@ class TuyaApi:
     @discovery_interval.setter
     def discovery_interval(self, val):
         if val < MIN_DISCOVERY_INTERVAL:
-            _LOGGER.warning(
-                "Discovery interval below %s is invalid", MIN_DISCOVERY_INTERVAL
+            raise ValueError(
+                f"Discovery interval below {MIN_DISCOVERY_INTERVAL} seconds is invalid"
             )
-            return
-
         self._discovery_interval = val
 
     @property
@@ -71,11 +69,9 @@ class TuyaApi:
     @query_interval.setter
     def query_interval(self, val):
         if val < MIN_QUERY_INTERVAL:
-            _LOGGER.warning(
-                "Query interval below %s is invalid", MIN_QUERY_INTERVAL
+            raise ValueError(
+                f"Query interval below {MIN_QUERY_INTERVAL} seconds is invalid"
             )
-            return
-
         self._query_interval = val
 
     def log_message(self, message, *args):

--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -12,10 +12,14 @@ from tuyaha.devices.factory import get_tuya_device
 TUYACLOUDURL = "https://px1.tuya{}.com"
 DEFAULTREGION = "us"
 
-MIN_DISCOVERY_INTERVAL = 10.0
-DEF_DISCOVERY_INTERVAL = 60.0
-MIN_QUERY_INTERVAL = 10.0
-DEF_QUERY_INTERVAL = 30.0
+# use related discovery_interval property to set correct value based on API discovery limits
+MIN_DISCOVERY_INTERVAL = 10.0  # 10 seconds
+DEF_DISCOVERY_INTERVAL = 60.0  # 60 seconds
+
+# use related query_interval property to set correct value based on API query limits
+MIN_QUERY_INTERVAL = 10.0  # 10 seconds
+DEF_QUERY_INTERVAL = 30.0  # 30 seconds
+
 REFRESHTIME = 60 * 60 * 12
 
 _LOGGER = logging.getLogger(__name__)

--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -13,8 +13,8 @@ from tuyaha.devices.factory import get_tuya_device
 TUYACLOUDURL = "https://px1.tuya{}.com"
 DEFAULTREGION = "us"
 
-MIN_DISCOVERY_INTERVAL = 25
-MAX_DISCOVERY_INTERVAL = 50
+MIN_DISCOVERY_INTERVAL = 305
+MAX_DISCOVERY_INTERVAL = 305
 REFRESHTIME = 60 * 60 * 12
 
 _LOGGER = logging.getLogger(__name__)

--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -12,11 +12,15 @@ from tuyaha.devices.factory import get_tuya_device
 TUYACLOUDURL = "https://px1.tuya{}.com"
 DEFAULTREGION = "us"
 
-# use related discovery_interval property to set correct value based on API discovery limits
+# Tuya API do not allow call to discovery command below specific limits
+# Use discovery_interval property to set correct value based on API discovery limits
+# Next 2 parameter define the default and minimum allowed value for the property
 MIN_DISCOVERY_INTERVAL = 10.0  # 10 seconds
 DEF_DISCOVERY_INTERVAL = 60.0  # 60 seconds
 
-# use related query_interval property to set correct value based on API query limits
+# Tuya API do not allow call to query command below specific limits
+# Use query_interval property to set correct value based on API query limits
+# Next 2 parameter define the default and minimum allowed value for the property
 MIN_QUERY_INTERVAL = 10.0  # 10 seconds
 DEF_QUERY_INTERVAL = 30.0  # 30 seconds
 
@@ -55,6 +59,7 @@ class TuyaApi:
 
     @property
     def discovery_interval(self):
+        """The interval in seconds between 2 consecutive device discovery"""
         return self._discovery_interval
 
     @discovery_interval.setter
@@ -67,6 +72,7 @@ class TuyaApi:
 
     @property
     def query_interval(self):
+        """The interval in seconds between 2 consecutive device query"""
         return self._query_interval
 
     @query_interval.setter
@@ -173,6 +179,8 @@ class TuyaApi:
             return True
         return False
 
+    # if discovery is called before that configured polling interval has passed
+    # it return cached data retrieved by previous successful call
     def discovery(self):
         with lock:
             if self._call_discovery():

--- a/tuyaha/tuyaapi.py
+++ b/tuyaha/tuyaapi.py
@@ -46,27 +46,37 @@ class TuyaApi:
         self._discovered_devices = None
         self._last_discover = None
         self._force_discovery = False
-        self._discovery_interval = 0.0
-        self._query_interval = 0.0
+        self._discovery_interval = DEF_DISCOVERY_INTERVAL
+        self._query_interval = DEF_QUERY_INTERVAL
         self._discovery_fail_count = 0
 
     @property
     def discovery_interval(self):
-        return self._discovery_interval or DEF_DISCOVERY_INTERVAL
+        return self._discovery_interval
 
     @discovery_interval.setter
     def discovery_interval(self, val):
-        if val >= MIN_DISCOVERY_INTERVAL:
-            self._discovery_interval = val
+        if val < MIN_DISCOVERY_INTERVAL:
+            _LOGGER.warning(
+                "Discovery interval below %s is invalid", MIN_DISCOVERY_INTERVAL
+            )
+            return
+
+        self._discovery_interval = val
 
     @property
     def query_interval(self):
-        return self._query_interval or DEF_QUERY_INTERVAL
+        return self._query_interval
 
     @query_interval.setter
     def query_interval(self, val):
-        if val >= MIN_QUERY_INTERVAL:
-            self._query_interval = val
+        if val < MIN_QUERY_INTERVAL:
+            _LOGGER.warning(
+                "Query interval below %s is invalid", MIN_QUERY_INTERVAL
+            )
+            return
+
+        self._query_interval = val
 
     def log_message(self, message, *args):
         if self._log_level_warn:


### PR DESCRIPTION
Hi,

I start to PR this change that basically try to limit the use of discovery method and cache retrieved data.
The intention is to share the result of one discovery call for all devices and at the same time limit the number of calls, also because in many case status device refresh fail with an error "FrequentlyInvoked".
This will also improve device detection  by HA component because cached data are used also for this.
For the moment I implemented this only for switch and cover, I think should be also extended (and can be quickly done) for light bulb, but not having a bulb I'm not sure about how to correctly update in the cache some of the state (brightness, color, etc). If you have one and time we can work also on this.

Please also consider that last pr #38 probably will break cover device because "state" attribute is not properly updated.